### PR TITLE
Using `--no-install-recommends` (Optimization)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,13 @@ FROM node:11.10.1-slim
 RUN apt-get update && \
     apt-get --no-install-recommends install -y git apt-utils sudo python make vim procps && \
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    && rm -rf \
+        /var/lib/apt/lists/* \
+        /tmp/* \
+        /var/tmp/* \
+        /usr/share/man \
+        /usr/share/doc \
+        /usr/share/doc-base
 
 WORKDIR /home/argocd/argocd-bot
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM argoproj/argocd:$ARGOCD_VERSION as argocd
 
 FROM node:11.10.1-slim
 
-RUN apt-get update && apt-get install -y git apt-utils sudo python make vim procps && \
+RUN apt-get update && \
+    apt-get --no-install-recommends install -y git apt-utils sudo python make vim procps && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
Line 7: Using `--no-install-recommends` (Optimization)

Using a --no-install-recommends when apt-get installing packages.

This will result in a smaller image size.